### PR TITLE
replacing cat with tee -a l.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ will control the rest of the demo.
 Raise the maximum processes limit.
 
 ```bash
-sudo cat >> /etc/security/limits.conf <<EOL
+sudo tee -a >> /etc/security/limits.conf <<EOL
 ec2-user soft nproc 16384
 ec2-user hard nproc 16384
 EOL


### PR DESCRIPTION
On line 32 replacing cat with tee -a to overcome the permissions issue.

*Issue #2 :*

*Description of changes:* 

The following command on Amazon Linux 2 on i3.metal instance:

sudo cat >> /etc/security/limits.conf <<EOL
ubuntu soft nproc 16384
ubuntu hard nproc 16384
EOL
is giving the following error:

-bash: /etc/security/limits.conf: Permission denied

Editing the file manually using sudo vim works

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
