### PR TITLE
Fix to logger config to correct extract-times.sh

### DIFF
--- a/start-firecracker.sh
+++ b/start-firecracker.sh
@@ -68,7 +68,7 @@ curl_put '/logger' <<EOF
 {
   "log_fifo": "$logfile",
   "metrics_fifo": "$metricsfile",
-  "level": "Warning",
+  "level": "Info",
   "show_level": false,
   "show_log_origin": false
 }


### PR DESCRIPTION
Fix as described in https://github.com/firecracker-microvm/firecracker-demo/issues/19

*Issue #, if available:*

*Description of changes:*

* When running the benchmark, the statistics generated by extract-times.sh cannot work as the information searched for is presented as an "Info" message and not "Warn" as in the script. You can see here what the necessary change is.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.