### PR TITLE
Updated firecracker-demo to v0.18.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ ec2-user hard nproc 16384
 EOL
 ```
 
+Note: In the above configuration, `ec2-user` is a
+placeholder for the ec2 instance logged in user.
+
 Reload the ssh session to have the new limit applied.
 
 Install additional dependencies: `python3` and `iperf3`.

--- a/start-firecracker.sh
+++ b/start-firecracker.sh
@@ -6,8 +6,8 @@ RO_DRIVE="$PWD/xenial.rootfs.ext4"
 KERNEL="$PWD/vmlinux"
 TAP_DEV="fc-${SB_ID}-tap0"
 
-KERNEL_BOOT_ARGS="panic=1 pci=off reboot=k tsc=reliable quiet 8250.nr_uarts=0 ipv6.disable=1 $R_INIT"
-#KERNEL_BOOT_ARGS="console=ttyS0 reboot=k panic=1 pci=off nomodules ipv6.disable=1 $R_INIT"
+KERNEL_BOOT_ARGS="panic=1 pci=off reboot=k tsc=reliable quiet 8250.nr_uarts=0 ipv6.disable=1"
+#KERNEL_BOOT_ARGS="console=ttyS0 reboot=k panic=1 pci=off nomodules ipv6.disable=1"
 
 API_SOCKET="/tmp/firecracker-sb${SB_ID}.sock"
 CURL=(curl --silent --show-error --header Content-Type:application/json --unix-socket "${API_SOCKET}" --write-out "HTTP %{http_code}")


### PR DESCRIPTION
#21 
Signed-off-by: iulianbarbu <iul@amazon.com>

Updated firecracker binary with the one compiled from tag v0.18.0.
Removed empty env variable (R_INIT) from start_firecracker.sh.
Added a note which clarifies the content added to /etc/security/limits.conf.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.