### PR TITLE
add CAP_NET_ADMIN to firecracker binary

### DIFF
--- a/one-time-setup.sh
+++ b/one-time-setup.sh
@@ -11,3 +11,6 @@ sudo sysctl -w net.ipv4.netfilter.ip_conntrack_max=99999999
 sudo sysctl -w net.ipv4.neigh.default.gc_thresh1=1024
 sudo sysctl -w net.ipv4.neigh.default.gc_thresh2=2048
 sudo sysctl -w net.ipv4.neigh.default.gc_thresh3=4096
+
+# Add CAP_NET_ADMIN to firecracker (for TUNSETIFF ioctl)
+sudo setcap cap_net_admin=eip firecracker


### PR DESCRIPTION
The unjailed `firecracker` binary needs this capability set for the `TUNSETIFF` ioctl.

By submitting this pull request, I confirm that my contribution is made
under the terms of the Apache 2.0 license.
